### PR TITLE
Develop

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -36,11 +36,20 @@ class ExternalModule extends AbstractExternalModule {
       $target_fields = AbstractExternalModule::getProjectSetting('ssptf_target_upload_field');
       $target_upload_field = $target_fields[$index];
 
-      //check if we can write to $target_upload_field else check other base name variations
+      $matches = array();
+      $index = 1;
+      $target_upload_field_name = $target_upload_field;
+      if (preg_match('#^(.+)_([0-9]+)$#', $target_upload_field, $matches)) {
+          $target_upload_field_name = $matches[1];
+          $index = (int)$matches[2];
+      }
+
+      //check if we can write to $target_upload_field_name else check other base name variations
       $writable = false;
-      for($count = 1; $count <= ATTEMPT_LIMIT + 1; $count++) {
-        if(doesFieldExist($target_upload_field . $extension) && !fieldHasValue($project_id, $record, $target_upload_field . $extension, $event)) {
-          $target_upload_field = $target_upload_field . $extension;
+      for($count = $index; $count <= ATTEMPT_LIMIT + 1; $count++) {
+        if(doesFieldExist($target_upload_field_name . $extension) && !fieldHasValue($project_id, $record, $target_upload_field_name . $extension, $event))
+        {
+          $target_upload_field_name = $target_upload_field_name . $extension;
           $writable = true;
           break;
         }
@@ -54,7 +63,7 @@ class ExternalModule extends AbstractExternalModule {
       if ($writable) {
         //upload pdf into designated upload field
         $doc_id = uploadPdfToEdocs($path_to_temp_file, $instrument);
-        setUploadField($project_id, $record, $event_id, $target_upload_field, $doc_id);
+        setUploadField($project_id, $record, $event_id, $target_upload_field_name, $doc_id);
       } else {
           //log failure
           logMessage("ERROR: PDF of an instrument could not be saved.");

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This REDCap module generates a PDF of a survey upon completion and saves it to a
 
 Before you can configure this module, you will need to create the surveys and fields needed for configuration. This module can save PDFs for as many surveys as desired, but each survey is saved as its own PDF. The PDFs must be saved to file upload fields in a non-survey instrument. On that instrument create a file upload field for each survey that needs to be saved.
 
-Should you need to save multiple revisions of a survey PDF for a single record\_id, use the Online Designer to copy the file upload file as many times as you need. This module will use the original field name as a basename and append '\_1', '\_2', '\_3', etc. looking for additional fields into which it can save the PDF. Also, set the source instrument as a repeating instrument so that the survey can be filled out multiple times.
+Should you need to save multiple revisions of a survey PDF for a single record\_id, use the Online Designer to copy the file upload file as many times as you need. This module will use the original field name as a basename and append '\_1', '\_2', '\_3', etc. looking for additional fields into which it can save the PDF. If your original field name has the following format `field_name_1`, the module will increment the number at the end of field name by `1` instead of appending '\_1', e.g. `target_field_3` will become `target_field_4` if `target_field_3` is unavailable.
 
 With the surveys and file upload fields created, you can proceed with module configuration.
 

--- a/config.json
+++ b/config.json
@@ -15,6 +15,11 @@
             "name": "Philip B. Chase",
             "email": "pbc@ufl.edu",
             "institution": "CTS-IT - University of Florida"
+        },
+	{
+            "name": "Marly Cormar",
+            "email": "marlycormar@ufl.edu",
+            "institution": "CTS-IT - University of Florida"
         }
       ],
     "system-settings" : [

--- a/config.json
+++ b/config.json
@@ -41,7 +41,7 @@
     "project-settings": [
       {
          "key": "ssptf_receiver_address",
-         "name": "Email address that should receive generated PDFs should this module be unable to save the PDF",
+         "name": "Email address that will receive generated PDFs should this module be unable to save the PDF",
          "required": true,
          "type": "text",
          "repeatable": false


### PR DESCRIPTION
New flexibility has been added in the naming of  the`target_upload_field`. 
For example, it can be named as:
- `field_name`,
- `field_name_1`, or
- `field_name_10` (i.e. there could be any number at the end of the field name*).

This module has been uploaded to `redcapb` with **v2.0** for testing purposes.

_*There is an upper bound for this number, namely 30. Not sure whether such bound is needed._