### PR TITLE
Enhanced functionality to permit saving copies of survey PDFs to multiple destination fields

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -43,7 +43,7 @@ class ExternalModule extends AbstractExternalModule {
 
 // Iterate along dictionary of matched keys
 for($count = 0; $count <= count($indices); $count++) {
-  $index = $indices[$count]
+  $index = $indices[$count];
 
 
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -30,7 +30,7 @@ class ExternalModule extends AbstractExternalModule {
       //check if instrument is the same one set in config
 
       //      $index = array_search($instrument, $source_instruments); //REMOVED
-      $indices = array_keys($instrument, $source_instruments);
+      $indices = array_keys($source_instruments,$instrument);
 
       //abort hook if not  //REMOVED
       if($index === FALSE) {   //REMOVED

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -44,7 +44,7 @@ class ExternalModule extends AbstractExternalModule {
       //Debug logging below - uncomment as needed //TODO: Update module to use emLogger
       //  \REDCap::logEvent($this->getModuleName(), "Found" .
       //  $match_cnt .
-      " matches", "", $record, $event_id); */
+      // " matches", "", $record, $event_id); */
     
 
       // Iterate along dictionary of targeted keys

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -33,18 +33,24 @@ class ExternalModule extends AbstractExternalModule {
       $indices = array_keys($source_instruments,$instrument);
 
       //abort hook if not  //REMOVED
-      if($index === FALSE) {   //REMOVED
+/*       if($index === FALSE) {   //REMOVED
         return 0;              //REMOVED
-      }                        //REMOVED
+      }      */                   //REMOVED
       //abort hook if not
       if($indices === FALSE) {
         return 0;
       }
+      $match_cnt=count($indices);
+      \REDCap::logEvent($this->getModuleName(), "Found" .
+      $match_cnt .
+      " matches", "", $record, $event_id);
+    
 
-// Iterate along dictionary of matched keys
+      // Iterate along dictionary of matched keys
 for($count = 0; $count <= count($indices); $count++) {
   $index = $indices[$count];
-
+  \REDCap::logEvent($this->getModuleName(), "Attempting" .
+  $index, "", $record, $event_id);
 
 
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -28,29 +28,44 @@ class ExternalModule extends AbstractExternalModule {
       $source_instruments = AbstractExternalModule::getProjectSetting('ssptf_source_instrument');
 
       //check if instrument is the same one set in config
-      $index = array_search($instrument, $source_instruments);
 
+      //      $index = array_search($instrument, $source_instruments); //REMOVED
+      $indices = array_keys($instrument, $source_instruments);
+
+      //abort hook if not  //REMOVED
+      if($index === FALSE) {   //REMOVED
+        return 0;              //REMOVED
+      }                        //REMOVED
       //abort hook if not
-      if($index === FALSE) {
+      if($indices === FALSE) {
         return 0;
       }
+
+// Iterate along dictionary of matched keys
+for($count = 0; $count <= count($indices); $count++) {
+  $index = $indices[$count]
+
+
+
+
+
 
       //get target upload field from config
       $target_fields = AbstractExternalModule::getProjectSetting('ssptf_target_upload_field');
       $target_upload_field = $target_fields[$index];
 
       $matches = array();
-      $index = 1;
+      $i = 1;
       $target_upload_field_name = $target_upload_field;
       if (preg_match('#^(.+)_([0-9]+)$#', $target_upload_field, $matches)) {
           $target_upload_field_name = $matches[1];
-          $index = (int)$matches[2];
+          $i = (int)$matches[2];
       }
 
       //check if we can write to $target_upload_field_name else check other base name variations
       $writable = false;
       $extension = '';
-      for($count = $index; $count <= ATTEMPT_LIMIT + 1; $count++) {
+      for($count = $i; $count <= ATTEMPT_LIMIT + 1; $count++) {
         $field = $target_upload_field_name . $extension;
         if(isset($Proj->metadata[$field]) && $Proj->metadata[$field]['element_type'] == 'file' && !fieldHasValue($project_id, $record, $field, $event_id))
         {
@@ -97,5 +112,6 @@ class ExternalModule extends AbstractExternalModule {
       }
 
       unlink($path_to_temp_file);
+    }
     }
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -42,7 +42,7 @@ class ExternalModule extends AbstractExternalModule {
       }
 
       \REDCap::logEvent($this->getModuleName(), "Dictionary: " .
-      $indices, "", $record, $event_id);
+      implode($indices), "", $record, $event_id);
     
 
       $match_cnt=count($indices);

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -52,7 +52,7 @@ class ExternalModule extends AbstractExternalModule {
     
 
       // Iterate along dictionary of matched keys
-for($match = 0; $match <= $match_cnt; $match++) {
+for($match = 0; $match <= $match_cnt-1; $match++) {
   \REDCap::logEvent($this->getModuleName(), "Pass number: " .
   $match, "", $record, $event_id);
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -28,110 +28,105 @@ class ExternalModule extends AbstractExternalModule {
       $source_instruments = AbstractExternalModule::getProjectSetting('ssptf_source_instrument');
 
       //check if instrument is the same one set in config
-
-      //      $index = array_search($instrument, $source_instruments); //REMOVED
       $indices = array_keys($source_instruments,$instrument);
 
-      //abort hook if not  //REMOVED
-      if($index === FALSE) {   //REMOVED
-        return 0;              //REMOVED
-      }                        //REMOVED
       //abort hook if not
       if($indices === FALSE) {
         return 0;
       }
 
-      \REDCap::logEvent($this->getModuleName(), "Dictionary: " .
-      implode(",",$indices), "", $record, $event_id);
+      //Debug logging below - uncomment as needed //TODO: Update module to use emLogger
+     /*  \REDCap::logEvent($this->getModuleName(), "Dictionary: " .
+      implode(",",$indices), "", $record, $event_id); */
+    
+      // Count number of matched targets
+      $target_cnt=count($indices);
+      //Debug logging below - uncomment as needed //TODO: Update module to use emLogger
+      //  \REDCap::logEvent($this->getModuleName(), "Found" .
+      //  $match_cnt .
+      " matches", "", $record, $event_id); */
     
 
-      $match_cnt=count($indices);
-      \REDCap::logEvent($this->getModuleName(), "Found" .
-      $match_cnt .
-      " matches", "", $record, $event_id);
-    
+      // Iterate along dictionary of targeted keys
+      for($target = 0; $target <= $target_cnt-1; $target++) {
+      //Debug logging below - uncomment as needed //TODO: Update module to use emLogger
+      //  \REDCap::logEvent($this->getModuleName(), "Pass number: " .
+      //  $match, "", $record, $event_id);
 
-      // Iterate along dictionary of matched keys
-for($match = 0; $match <= $match_cnt-1; $match++) {
-  \REDCap::logEvent($this->getModuleName(), "Pass number: " .
-  $match, "", $record, $event_id);
+        // Recover index for the current target
+         $index = $indices[$target];
 
-  // Recover index for the current match
-  $index = $indices[$match];
-  \REDCap::logEvent($this->getModuleName(), "Checking index: " .
-  $index, "", $record, $event_id);
+        //Debug logging below - uncomment as needed //TODO: Update module to use emLogger
+        //  \REDCap::logEvent($this->getModuleName(), "Checking index: " .
+        //  $index, "", $record, $event_id);
 
+        //get target upload field from config
+        $target_fields = AbstractExternalModule::getProjectSetting('ssptf_target_upload_field');
+        $target_upload_field = $target_fields[$index];
 
+        //Debug logging below - uncomment as needed //TODO: Update module to use emLogger
+        //  \REDCap::logEvent($this->getModuleName(), "Attempting to write to: " .
+        //  $target_upload_field, "", $record, $event_id); */
 
-
-
-
-      //get target upload field from config
-      $target_fields = AbstractExternalModule::getProjectSetting('ssptf_target_upload_field');
-      $target_upload_field = $target_fields[$index];
-      \REDCap::logEvent($this->getModuleName(), "Attempting to write to: " .
-      $target_upload_field, "", $record, $event_id);
-
-
-
-      $matches = array();
-      $i = 1;
-      $target_upload_field_name = $target_upload_field;
-      if (preg_match('#^(.+)_([0-9]+)$#', $target_upload_field, $matches)) {
-          $target_upload_field_name = $matches[1];
-          $i = (int)$matches[2];
-      }
-
-      //check if we can write to $target_upload_field_name else check other base name variations
-      $writable = false;
-      $extension = '';
-      for($count = $i; $count <= ATTEMPT_LIMIT + 1; $count++) {
-        $field = $target_upload_field_name . $extension;
-        if(isset($Proj->metadata[$field]) && $Proj->metadata[$field]['element_type'] == 'file' && !fieldHasValue($project_id, $record, $field, $event_id))
-        {
-          $target_upload_field_name = $field;
-          $writable = true;
-          break;
+        //Determine target field name
+        $matches = array();
+        $i = 1;
+        $target_upload_field_name = $target_upload_field;
+        if (preg_match('#^(.+)_([0-9]+)$#', $target_upload_field, $matches)) {
+            $target_upload_field_name = $matches[1];
+            $i = (int)$matches[2];
         }
 
-        $extension = "_" . $count;
-      }
-
-      //make pdf and store it in a temp directory
-      $path_to_temp_file = makePDF($project_id, $record, $instrument, $event_id, $repeat_instance);
-
-      if ($writable) {
-          //upload pdf into designated upload field
-          $doc_id = uploadPdfToEdocs($path_to_temp_file, $instrument);
-          setUploadField($project_id, $record, $event_id, $target_upload_field_name, $doc_id);
-
-          REDCap::logEvent("save_survey_pdf_to_field", "save_survey_pdf_to_field uploaded a new PDF to a field.\n$target_upload_field_name = $doc_id", null, $record, $event_id, $project_id);
-      } else {
-          //log failure
-          REDCap::logEvent("save_survey_pdf_to_field alert", "save_survey_pdf_to_field failed to save a PDF from the '$instrument' instrument to the '$target_upload_field_name' field.", null, $record, $event_id, $project_id);
-
-          //send error email
-          $receiver_addr = AbstractExternalModule::getProjectSetting('ssptf_receiver_address');
-          $sender_addr = AbstractExternalModule::getSystemSetting('ssptf_sender_address');
-          $cc = AbstractExternalModule::getSystemSetting('ssptf_cc');
-          $subject = "ERROR: PDF of REDCap instrument could not be saved.";
-          $url = APP_PATH_WEBROOT_FULL . 'redcap_v' . $redcap_version . "/DataEntry/record_home.php?pid=" . $project_id . "&id=" . $record . "&arm=" . getArm();
-          $body = "ERROR: REDCap failed to save a PDF of an instrument for this
-          research subject: " . "<a href=\"". $url . "\">" . $url . "</a>" .
-          " That document is attached to this message. Please review this REDCap
-          project's configuration, make changes as needed,and upload this PDF to
-          this research subject's record.";
-          $sent = sendEmail($receiver_addr, $sender_addr, $cc, $subject, $body, $path_to_temp_file);
-
-          //notify user if email failed to send
-          if (!$sent) {
-            REDCap::logEvent("save_survey_pdf_to_field alert", "save_survey_pdf_to_field could not send email containing the PDF from the '$instrument' instrument.", null, $record, $event_id, $project_id);
-          } else {
-            REDCap::logEvent("save_survey_pdf_to_field alert", "save_survey_pdf_to_field sent an email containing the PDF from the '$instrument' instrument.", null, $record, $event_id, $project_id);
+        //check if we can write to $target_upload_field_name else check other base name variations
+        $writable = false;
+        $extension = '';
+        for($count = $i; $count <= ATTEMPT_LIMIT + 1; $count++) {
+          $field = $target_upload_field_name . $extension;
+          if(isset($Proj->metadata[$field]) && $Proj->metadata[$field]['element_type'] == 'file' && !fieldHasValue($project_id, $record, $field, $event_id))
+          {
+            $target_upload_field_name = $field;
+            $writable = true;
+            break;
           }
-      }
 
-      unlink($path_to_temp_file);
-    }
+          $extension = "_" . $count;
+        }
+
+        //make pdf and store it in a temp directory
+        $path_to_temp_file = makePDF($project_id, $record, $instrument, $event_id, $repeat_instance);
+
+        if ($writable) {
+            //upload pdf into designated upload field
+            $doc_id = uploadPdfToEdocs($path_to_temp_file, $instrument);
+            setUploadField($project_id, $record, $event_id, $target_upload_field_name, $doc_id);
+
+            REDCap::logEvent("save_survey_pdf_to_field", "save_survey_pdf_to_field uploaded a new PDF to a field.\n$target_upload_field_name = $doc_id", null, $record, $event_id, $project_id);
+        } else {
+            //log failure
+            REDCap::logEvent("save_survey_pdf_to_field alert", "save_survey_pdf_to_field failed to save a PDF from the '$instrument' instrument to the '$target_upload_field_name' field.", null, $record, $event_id, $project_id);
+
+            //send error email
+            $receiver_addr = AbstractExternalModule::getProjectSetting('ssptf_receiver_address');
+            $sender_addr = AbstractExternalModule::getSystemSetting('ssptf_sender_address');
+            $cc = AbstractExternalModule::getSystemSetting('ssptf_cc');
+            $subject = "ERROR: PDF of REDCap instrument could not be saved.";
+            $url = APP_PATH_WEBROOT_FULL . 'redcap_v' . $redcap_version . "/DataEntry/record_home.php?pid=" . $project_id . "&id=" . $record . "&arm=" . getArm();
+            $body = "ERROR: REDCap failed to save a PDF of an instrument for this
+            research subject: " . "<a href=\"". $url . "\">" . $url . "</a>" .
+            " That document is attached to this message. Please review this REDCap
+            project's configuration, make changes as needed,and upload this PDF to
+            this research subject's record.";
+            $sent = sendEmail($receiver_addr, $sender_addr, $cc, $subject, $body, $path_to_temp_file);
+
+            //notify user if email failed to send
+            if (!$sent) {
+              REDCap::logEvent("save_survey_pdf_to_field alert", "save_survey_pdf_to_field could not send email containing the PDF from the '$instrument' instrument.", null, $record, $event_id, $project_id);
+            } else {
+              REDCap::logEvent("save_survey_pdf_to_field alert", "save_survey_pdf_to_field sent an email containing the PDF from the '$instrument' instrument.", null, $record, $event_id, $project_id);
+            }
+        }
+
+        unlink($path_to_temp_file);
+      }
     }
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -56,6 +56,7 @@ for($count = 0; $count <= $match_cnt; $count++) {
   \REDCap::logEvent($this->getModuleName(), "Pass number: " .
   $count, "", $record, $event_id);
 
+  // Recover index for the current match
   $index = $indices[$count];
   \REDCap::logEvent($this->getModuleName(), "Checking index: " .
   $index, "", $record, $event_id);
@@ -68,6 +69,10 @@ for($count = 0; $count <= $match_cnt; $count++) {
       //get target upload field from config
       $target_fields = AbstractExternalModule::getProjectSetting('ssptf_target_upload_field');
       $target_upload_field = $target_fields[$index];
+      \REDCap::logEvent($this->getModuleName(), "Attempting to write to: " .
+      $target_upload_field, "", $record, $event_id);
+
+
 
       $matches = array();
       $i = 1;

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -33,18 +33,32 @@ class ExternalModule extends AbstractExternalModule {
       $indices = array_keys($source_instruments,$instrument);
 
       //abort hook if not  //REMOVED
-      if($index === FALSE) {   //REMOVED
+/*       if($index === FALSE) {   //REMOVED
         return 0;              //REMOVED
-      }                        //REMOVED
+      }      */                   //REMOVED
       //abort hook if not
       if($indices === FALSE) {
         return 0;
       }
 
-// Iterate along dictionary of matched keys
-for($count = 0; $count <= count($indices); $count++) {
-  $index = $indices[$count];
+      \REDCap::logEvent($this->getModuleName(), "Dictionary: " .
+      $indices, "", $record, $event_id);
+    
 
+      $match_cnt=count($indices);
+      \REDCap::logEvent($this->getModuleName(), "Found" .
+      $match_cnt .
+      " matches", "", $record, $event_id);
+    
+
+      // Iterate along dictionary of matched keys
+for($count = 0; $count <= $match_cnt; $count++) {
+  \REDCap::logEvent($this->getModuleName(), "Pass number: " .
+  $count, "", $record, $event_id);
+
+  $index = $indices[$count];
+  \REDCap::logEvent($this->getModuleName(), "Checking index: " .
+  $index, "", $record, $event_id);
 
 
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -42,7 +42,7 @@ class ExternalModule extends AbstractExternalModule {
       }
 
       \REDCap::logEvent($this->getModuleName(), "Dictionary: " .
-      implode($indices), "", $record, $event_id);
+      implode(",",$indices), "", $record, $event_id);
     
 
       $match_cnt=count($indices);
@@ -52,12 +52,12 @@ class ExternalModule extends AbstractExternalModule {
     
 
       // Iterate along dictionary of matched keys
-for($count = 0; $count <= $match_cnt; $count++) {
+for($match = 0; $match <= $match_cnt; $match++) {
   \REDCap::logEvent($this->getModuleName(), "Pass number: " .
-  $count, "", $record, $event_id);
+  $match, "", $record, $event_id);
 
   // Recover index for the current match
-  $index = $indices[$count];
+  $index = $indices[$match];
   \REDCap::logEvent($this->getModuleName(), "Checking index: " .
   $index, "", $record, $event_id);
 


### PR DESCRIPTION
This correction makes use of the `array_keys` array function (which returns multiple matches) to replace the `array_search` function (which returns only the first match).  I added a loop around the main flow of the module using the results of the output, and corrected one overloaded variable (`$index`).  

You'll note several sections for code debugging to log to the REDCap event log.  A useful integration down the road will be with the emLogger EM, which would provide debug logging without interfering with the main REDCap event log.  For now I've just commented out the logging steps. 

Resolves #16 .